### PR TITLE
refactor(pkg): migrate svg2png-wasm to @resvg/resvg-js

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -4,7 +4,7 @@
   "package": "./package.json",
   "reporter": "spec",
   "slow": 30000,
-  "timeout": 10000,
+  "timeout": 20000,
   "ui": "bdd",
   "watch-files": ["test/*.test.js"],
   "watch-ignore": ["node_modules"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@resvg/resvg-js": "^1.3.0",
         "domino": "^2.1.6",
         "jimp": "^0.16.1",
-        "oslllo-validator": "3.0.0",
-        "svg2png-wasm-node-10": "^1.3.1"
+        "oslllo-validator": "3.0.0"
       },
       "devDependencies": {
         "chai": "^4.3.4",
@@ -614,6 +614,208 @@
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "regenerator-runtime": "^0.13.3"
+      }
+    },
+    "node_modules/@resvg/resvg-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-1.3.0.tgz",
+      "integrity": "sha512-oryhplDvtf0qq0o/TOWstTt2FtETNjdT+RKCN1kUys7204xs+zsLNbEg+g0i55rpsqxeSsfTiy37K15MG9rIqQ==",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "1.3.0",
+        "@resvg/resvg-js-android-arm64": "1.3.0",
+        "@resvg/resvg-js-darwin-arm64": "1.3.0",
+        "@resvg/resvg-js-darwin-x64": "1.3.0",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "1.3.0",
+        "@resvg/resvg-js-linux-arm64-gnu": "1.3.0",
+        "@resvg/resvg-js-linux-arm64-musl": "1.3.0",
+        "@resvg/resvg-js-linux-x64-gnu": "1.3.0",
+        "@resvg/resvg-js-linux-x64-musl": "1.3.0",
+        "@resvg/resvg-js-win32-arm64-msvc": "1.3.0",
+        "@resvg/resvg-js-win32-ia32-msvc": "1.3.0",
+        "@resvg/resvg-js-win32-x64-msvc": "1.3.0"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-1.3.0.tgz",
+      "integrity": "sha512-QjoiWJbXIcP5RkRSiKu5VRkkR6j9FMIShApr1fjuwkVEyijT1l62XQfQKaIhAVX4ash4/lFcwK6qH3H8r0R2FA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-1.3.0.tgz",
+      "integrity": "sha512-tEOh+t9/4sXnGI76+Q2hZPtU8R1Df4ZBnVstiS8KOX4vAZAvSYGrc/ds2VO/1kG0hp7OpqoLU+1pYBuvSvlIcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-u3uT8YHB7g+rT6hYCka9L6gjgpSPpIeSnnyFHFST5PSetjvMFwFJTnBcOdX1JRN2PObAVM8vtC/wJckfUqOJBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-wjLoG4KwU5OH1OyZf4oy+lfKIQfP74MyKNW2wNfXV8/8Aks/ak1KZG1p7uT7RvHljRyT/ts52LSTovu5jlFj+w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-1.3.0.tgz",
+      "integrity": "sha512-ocCZrre7LM+Zv2QfyitfW6v4Qvc5LsDa62WwiHy44VO7o/2ukYgBWcfu1pWZizY9LxOk0V6bmjKOdwqGzfHGRA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-2nQWxe69UArL6Qar+o72SSrY38kOsz4unn+3W2ybl9WqG/xLnYRyySH1UEQTMaFJvtnpnHUJ+Mo2n77cCE8aow==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-0XrLYFS7r/OrVIEmj1vKZT/U3Yph/y+yrBzI/Fio++nQVHgiNXi5X4/DCK7YcGmqtTq4JT94+OW8NIRW00dLqQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-aXVmKDmPWre70MT/fZ5mRBI8BKsWt6B58PZSqUOKupuZGmZ5kMJ+NS9IKMTHUkPLL5tCiCaJJRSyiuyF02q+Bg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-3UdObhMFEnh7pjmPrcKJ7r2QTlKEa+BHq0RxA7M7K6RQs2nxip7op1YG1XdCX5/EGmbg+dG9PyEnioRRCMmsOA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-1.3.0.tgz",
+      "integrity": "sha512-vTPpPtJtABub1N68M1QJrceBdfDtInwsorCjO4Ch+t9znB7YPP0B3xpXNH3s09unpbX9MO6yzR3U29mUvKFdsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-1.3.0.tgz",
+      "integrity": "sha512-qLLUb3/YaitK02V860/oRZa3KFENADPw544EUA6idowsvoIu1Q9xYI5uBHQCjPXaoAYD7kHuYLl6DFYStvNLYw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-1.3.0.tgz",
+      "integrity": "sha512-aivqvtXRzBAdVV6HrP8MrziXa9IiX5sdUF+Dj/8/bkxPT3UutMkN4thTlTNDoaE9yX2VBiheTReOiPpWB6ScyA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@types/color-name": {
@@ -3266,11 +3468,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/svg2png-wasm-node-10": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/svg2png-wasm-node-10/-/svg2png-wasm-node-10-1.3.1.tgz",
-      "integrity": "sha512-qwRYNe6m/d9hw8zm5PTxNCIhzwxMnDpDkNfd9z8Kpz4INtC9Vpd847Z2ZIiDqVXsM5I4C8crwR8LCclMoRsf8Q=="
-    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -4301,6 +4498,97 @@
         "@babel/runtime": "^7.7.2",
         "regenerator-runtime": "^0.13.3"
       }
+    },
+    "@resvg/resvg-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-1.3.0.tgz",
+      "integrity": "sha512-oryhplDvtf0qq0o/TOWstTt2FtETNjdT+RKCN1kUys7204xs+zsLNbEg+g0i55rpsqxeSsfTiy37K15MG9rIqQ==",
+      "requires": {
+        "@resvg/resvg-js-android-arm-eabi": "1.3.0",
+        "@resvg/resvg-js-android-arm64": "1.3.0",
+        "@resvg/resvg-js-darwin-arm64": "1.3.0",
+        "@resvg/resvg-js-darwin-x64": "1.3.0",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "1.3.0",
+        "@resvg/resvg-js-linux-arm64-gnu": "1.3.0",
+        "@resvg/resvg-js-linux-arm64-musl": "1.3.0",
+        "@resvg/resvg-js-linux-x64-gnu": "1.3.0",
+        "@resvg/resvg-js-linux-x64-musl": "1.3.0",
+        "@resvg/resvg-js-win32-arm64-msvc": "1.3.0",
+        "@resvg/resvg-js-win32-ia32-msvc": "1.3.0",
+        "@resvg/resvg-js-win32-x64-msvc": "1.3.0"
+      }
+    },
+    "@resvg/resvg-js-android-arm-eabi": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-1.3.0.tgz",
+      "integrity": "sha512-QjoiWJbXIcP5RkRSiKu5VRkkR6j9FMIShApr1fjuwkVEyijT1l62XQfQKaIhAVX4ash4/lFcwK6qH3H8r0R2FA==",
+      "optional": true
+    },
+    "@resvg/resvg-js-android-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-1.3.0.tgz",
+      "integrity": "sha512-tEOh+t9/4sXnGI76+Q2hZPtU8R1Df4ZBnVstiS8KOX4vAZAvSYGrc/ds2VO/1kG0hp7OpqoLU+1pYBuvSvlIcg==",
+      "optional": true
+    },
+    "@resvg/resvg-js-darwin-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-u3uT8YHB7g+rT6hYCka9L6gjgpSPpIeSnnyFHFST5PSetjvMFwFJTnBcOdX1JRN2PObAVM8vtC/wJckfUqOJBA==",
+      "optional": true
+    },
+    "@resvg/resvg-js-darwin-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-wjLoG4KwU5OH1OyZf4oy+lfKIQfP74MyKNW2wNfXV8/8Aks/ak1KZG1p7uT7RvHljRyT/ts52LSTovu5jlFj+w==",
+      "optional": true
+    },
+    "@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-1.3.0.tgz",
+      "integrity": "sha512-ocCZrre7LM+Zv2QfyitfW6v4Qvc5LsDa62WwiHy44VO7o/2ukYgBWcfu1pWZizY9LxOk0V6bmjKOdwqGzfHGRA==",
+      "optional": true
+    },
+    "@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-2nQWxe69UArL6Qar+o72SSrY38kOsz4unn+3W2ybl9WqG/xLnYRyySH1UEQTMaFJvtnpnHUJ+Mo2n77cCE8aow==",
+      "optional": true
+    },
+    "@resvg/resvg-js-linux-arm64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-0XrLYFS7r/OrVIEmj1vKZT/U3Yph/y+yrBzI/Fio++nQVHgiNXi5X4/DCK7YcGmqtTq4JT94+OW8NIRW00dLqQ==",
+      "optional": true
+    },
+    "@resvg/resvg-js-linux-x64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-aXVmKDmPWre70MT/fZ5mRBI8BKsWt6B58PZSqUOKupuZGmZ5kMJ+NS9IKMTHUkPLL5tCiCaJJRSyiuyF02q+Bg==",
+      "optional": true
+    },
+    "@resvg/resvg-js-linux-x64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-3UdObhMFEnh7pjmPrcKJ7r2QTlKEa+BHq0RxA7M7K6RQs2nxip7op1YG1XdCX5/EGmbg+dG9PyEnioRRCMmsOA==",
+      "optional": true
+    },
+    "@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-1.3.0.tgz",
+      "integrity": "sha512-vTPpPtJtABub1N68M1QJrceBdfDtInwsorCjO4Ch+t9znB7YPP0B3xpXNH3s09unpbX9MO6yzR3U29mUvKFdsw==",
+      "optional": true
+    },
+    "@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-1.3.0.tgz",
+      "integrity": "sha512-qLLUb3/YaitK02V860/oRZa3KFENADPw544EUA6idowsvoIu1Q9xYI5uBHQCjPXaoAYD7kHuYLl6DFYStvNLYw==",
+      "optional": true
+    },
+    "@resvg/resvg-js-win32-x64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-1.3.0.tgz",
+      "integrity": "sha512-aivqvtXRzBAdVV6HrP8MrziXa9IiX5sdUF+Dj/8/bkxPT3UutMkN4thTlTNDoaE9yX2VBiheTReOiPpWB6ScyA==",
+      "optional": true
     },
     "@types/color-name": {
       "version": "1.1.1",
@@ -6420,11 +6708,6 @@
           "dev": true
         }
       }
-    },
-    "svg2png-wasm-node-10": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/svg2png-wasm-node-10/-/svg2png-wasm-node-10-1.3.1.tgz",
-      "integrity": "sha512-qwRYNe6m/d9hw8zm5PTxNCIhzwxMnDpDkNfd9z8Kpz4INtC9Vpd847Z2ZIiDqVXsM5I4C8crwR8LCclMoRsf8Q=="
     },
     "test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -47,10 +47,10 @@
   },
   "homepage": "https://docs.oslllo.com/svg2/master",
   "dependencies": {
+    "@resvg/resvg-js": "^1.3.0",
     "domino": "^2.1.6",
     "jimp": "^0.16.1",
-    "oslllo-validator": "3.0.0",
-    "svg2png-wasm-node-10": "^1.3.1"
+    "oslllo-validator": "3.0.0"
   },
   "devDependencies": {
     "chai": "^4.3.4",

--- a/src/svg.js
+++ b/src/svg.js
@@ -1,19 +1,10 @@
 "use strict";
 
-const fs = require("fs");
 const Svg2 = require("..");
 const error = require("./error");
 const is = require("oslllo-validator");
 const constants = require("./constants");
-const { svg2png, initialize } = require("svg2png-wasm-node-10");
-const wasm = require.resolve("svg2png-wasm-node-10").replace(/(svg2png-wasm-node-10).*/, "$1/svg2png_wasm_bg.wasm");
-
-const init = async () => {
-  await initialize(fs.readFileSync(wasm));
-};
-
-let initPromise;
-
+const { renderAsync } = require("@resvg/resvg-js");
 const Svg = function (instance) {
   this.instance = instance;
   this.update(instance.toElement(instance.input.string), true);
@@ -86,10 +77,8 @@ Svg.prototype = {
     return this.instance.input.string;
   },
   png: async function (svg) {
-    initPromise = initPromise || init();
-    await initPromise;
-    const png = await svg2png(svg);
-    return Buffer.from(png);
+    const png = await renderAsync(svg);
+    return png;
   },
   element: function () {
     return this.instance.input.element;


### PR DESCRIPTION
This PR will migrate to [@resvg/resvg-js](https://github.com/yisibl/resvg-js#benchmark), which is the native Node.js addon, as opposed to WASM.

- Better performance 🚀🚀🚀, see also: https://github.com/yisibl/resvg-js#benchmark
- No memory limit

Rest assured, none of this requires node-gyp and postinstall.